### PR TITLE
fixes https://github.com/OpenVoiceOS/ovos-color-parser/issues/29

### DIFF
--- a/ovos_color_parser/matching.py
+++ b/ovos_color_parser/matching.py
@@ -114,7 +114,11 @@ class ColorMatcher:
                         if s >= 0.15:
                             #print(f"DEBUG: matched fuzzy color -> {(n, h, s)}")
                             weights.append(s)
-                            candidates.append(HLSColor.from_hex_str(h, name=n))
+                            try:
+                                candidates.append(HLSColor.from_hex_str(h, name=n))
+                            except ValueError as e:
+                                #print(f"DEBUG: {e}")
+                                pass
             else:
                 hex_strs = cls.match_automaton(automaton, description)
                 for hex_str in hex_strs:

--- a/ovos_color_parser/models.py
+++ b/ovos_color_parser/models.py
@@ -55,9 +55,14 @@ class sRGBAColor:
     def from_hex_str(hex_str: str, name: Optional[str] = None, description: Optional[str] = None) -> 'sRGBAColor':
         if hex_str.startswith('#'):
             hex_str = hex_str[1:]
-        r = int(hex_str[0:2], 16)
-        g = int(hex_str[2:4], 16)
-        b = int(hex_str[4:6], 16)
+        if len(hex_str) == 6:
+            r = int(hex_str[0:2], 16)
+            g = int(hex_str[2:4], 16)
+            b = int(hex_str[4:6], 16)
+        if len(hex_str) == 3:
+            r = int(hex_str[0:1], 16)
+            g = int(hex_str[1:2], 16)
+            b = int(hex_str[2:3], 16)
         return sRGBAColor(r, g, b, name=name, description=description)
 
     def __post_init__(self):

--- a/ovos_color_parser/models.py
+++ b/ovos_color_parser/models.py
@@ -59,10 +59,12 @@ class sRGBAColor:
             r = int(hex_str[0:2], 16)
             g = int(hex_str[2:4], 16)
             b = int(hex_str[4:6], 16)
-        if len(hex_str) == 3:
-            r = int(hex_str[0:1], 16)
-            g = int(hex_str[1:2], 16)
-            b = int(hex_str[2:3], 16)
+        elif len(hex_str) == 3:
+            r = int(hex_str[0:1] * 2, 16)
+            g = int(hex_str[1:2] * 2, 16)
+            b = int(hex_str[2:3] * 2, 16)
+        else:
+            raise ValueError(f"Invalid hex sting {hex_str}")
         return sRGBAColor(r, g, b, name=name, description=description)
 
     def __post_init__(self):


### PR DESCRIPTION
The issue was in parsing 3 digit hex codes.  This is a fix for this particular case, but there may be a better way.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Hex color parsing now accepts both 6‑digit and 3‑digit shorthand formats, with optional leading '#' support for wider input compatibility.

* **Bug Fixes**
  * Fuzzy color matching is now resilient to invalid color strings—unparseable candidates are skipped so matching continues without errors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->