### PR TITLE
Feat: added 'as_rgb' property to sRGBAColor class

### DIFF
--- a/ovos_color_parser/models.py
+++ b/ovos_color_parser/models.py
@@ -29,7 +29,7 @@ class sRGBAColor:
 
     @property
     def as_rgb(self) -> 'RGBa Tuple':
-        return (self.r, self.g, self.b, self.a)
+        return (self.r, self.g, self.b)
     
     @property
     def as_hls(self) -> 'HLSColor':

--- a/ovos_color_parser/models.py
+++ b/ovos_color_parser/models.py
@@ -28,6 +28,10 @@ class sRGBAColor:
         return self.as_hsv.as_spectral_color
 
     @property
+    def as_rgb(self) -> 'RGBa Tuple':
+        return (self.r, self.g, self.b, self.a)
+    
+    @property
     def as_hls(self) -> 'HLSColor':
         r = self.r / 255
         g = self.g / 255


### PR DESCRIPTION
Allows for an RGB value to be easily acquired from the sRGBAColor class

```
from ovos_color_parser.matching import color_from_description

color = color_from_description("mycroft blue")
print(color.as_rgb) 


>>> (16, 85, 224)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added direct access to RGB components from color objects, making it easier to retrieve and work with an (R, G, B) tuple for color conversion and manipulation.
* **Chores**
  * Public API extended to include the new RGB-access property for downstream use.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->