### PR TITLE
fix: correct color math and matching contract bugs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,7 @@
+__pycache__/
+*.pyc
+.coverage
+htmlcov/
+dist/
+build/
+*.egg-info/

--- a/ovos_color_parser/__init__.py
+++ b/ovos_color_parser/__init__.py
@@ -1,5 +1,8 @@
 from ovos_color_parser.models import (sRGBAColor, sRGBAColorPalette, HSVColorPalette, HLSColorPalette, HLSColor,
-                                      HueRange, HSVColor, SpectralColor, SpectralColorPalette,
+                                      HueRange, HSVColor, SpectralColor, SpectralColorPalette, ColorTerm,
+                                      LanguageColorVocabulary,
                                       NewtonSpectralColorTerms, ISCCNBSSpectralColorTerms, EnglishColorTerms)
 from ovos_color_parser.matching import (get_contrasting_black_or_white, color_distance, closest_color,
-                                        color_from_description, convert_K_to_RGB, average_colors, ColorMatcher)
+                                        color_from_description, palette_from_description, lookup_name,
+                                        convert_K_to_RGB, average_colors, ColorMatcher,
+                                        is_hex_code_valid, rgb_to_cmyk, cmyk_to_rgb)

--- a/ovos_color_parser/matching.py
+++ b/ovos_color_parser/matching.py
@@ -146,7 +146,7 @@ class ColorMatcher:
     @classmethod
     def match_color_automaton(cls, description: str, lang: str = "en",
                               strategy: MatchStrategy = MatchStrategy.DAMERAU_LEVENSHTEIN_SIMILARITY,
-                              fuzzy: bool = False) -> Tuple[HLSColor, float]:
+                              fuzzy: bool = False) -> List[Tuple[HLSColor, float]]:
         automaton = ColorMatcher.load_color_automaton(lang)
         candidates = []
         weights = []
@@ -176,11 +176,12 @@ class ColorMatcher:
                         weights.append(s)
                         candidates.append(HLSColor.from_hex_str(hex_str, name=name))
         #print(candidates, weights)
-        return zip(candidates, weights)
+        return list(zip(candidates, weights))
 
     @classmethod
     def match_object_automaton(cls, description: str, lang: str = "en",
-                               strategy: MatchStrategy = MatchStrategy.DAMERAU_LEVENSHTEIN_SIMILARITY):
+                               strategy: MatchStrategy = MatchStrategy.DAMERAU_LEVENSHTEIN_SIMILARITY
+                               ) -> List[Tuple[HLSColor, float]]:
         obj_dict = cls._get_object_colors(lang)
         automaton = ColorMatcher.load_object_automaton(lang)
         hex_strs = cls.match_automaton(automaton, description)
@@ -192,7 +193,7 @@ class ColorMatcher:
             name = obj_dict[hex_s]
             weights.append(fuzzy_match(name, description, strategy=strategy))
             candidates.append(HLSColor.from_hex_str(hex_s, name=name))
-        return zip(candidates, weights)
+        return list(zip(candidates, weights))
 
 
 def _get_color_adjectives(lang: str) -> Dict[str, List[str]]:
@@ -216,47 +217,51 @@ def _adjust_color_attributes(color: Color, description: str, adjectives: dict) -
 
     description = description.lower().strip()
 
+    def matches(key: str) -> bool:
+        return any(word.lower() in description for word in adjectives.get(key, []))
+
     # Saturation adjustments with additive/subtractive control
-    if any(word.lower() in description for word in adjectives["very_high_saturation"]):
+    if matches("very_high_saturation"):
         color.s = min(1.0, color.s + 0.2)  # Increase saturation
-    elif any(word.lower() in description for word in adjectives["high_saturation"]):
+    elif matches("high_saturation"):
         color.s = min(1.0, color.s + 0.1)
-    elif any(word.lower() in description for word in adjectives["low_saturation"]):
+    elif matches("low_saturation"):
         color.s = max(0.0, color.s - 0.1)
-    elif any(word.lower() in description for word in adjectives["very_low_saturation"]):
+    elif matches("very_low_saturation"):
         color.s = max(0.0, color.s - 0.2)
 
     # Brightness adjustments with gamma-like control
-    if any(word.lower() in description for word in adjectives["very_high_brightness"]):
+    if matches("very_high_brightness"):
         color.l = min(1.0, color.l + 0.2)
-    elif any(word.lower() in description for word in adjectives["high_brightness"]):
+    elif matches("high_brightness"):
         color.l = min(1.0, color.l + 0.1)
-    elif any(word.lower() in description for word in adjectives["low_brightness"]):
+    elif matches("low_brightness"):
         color.l = max(0.0, color.l - 0.1)
-    elif any(word.lower() in description for word in adjectives["very_low_brightness"]):
+    elif matches("very_low_brightness"):
         color.l = max(0.0, color.l - 0.2)
 
-    # Opacity adjustments
-    if any(word.lower() in description for word in adjectives["very_high_opacity"]):
-        color.a = min(1.0, color.a * 1.5)
-    elif any(word.lower() in description for word in adjectives["high_opacity"]):
-        color.a = min(1.0, color.a * 1.2)
-    elif any(word.lower() in description for word in adjectives["low_opacity"]):
-        color.a = max(0.0, color.a * 0.7)
-    elif any(word.lower() in description for word in adjectives["very_low_opacity"]):
-        color.a = max(0.0, color.a * 0.5)
-
-    # Temperature adjustments using RGB tinting
     color = color.as_rgb
-    if any(word.lower() in description for word in adjectives["very_high_temperature"]):
-        color.r = min(1.0, color.r + 0.1)
-        color.g = max(0.0, color.g - 0.05)  # Add warmth by reducing blue tones
-    elif any(word.lower() in description for word in adjectives["high_temperature"]):
-        color.r = min(1.0, color.r + 0.05)
-    elif any(word.lower() in description for word in adjectives["low_temperature"]):
-        color.b = min(1.0, color.b + 0.05)  # Add coolness by increasing blue tones
-    elif any(word.lower() in description for word in adjectives["very_low_temperature"]):
-        color.b = min(1.0, color.b + 0.1)
+
+    # Opacity adjustments (alpha channel, 0-255)
+    if matches("very_high_opacity"):
+        color.a = min(255, round(color.a * 1.5))
+    elif matches("high_opacity"):
+        color.a = min(255, round(color.a * 1.2))
+    elif matches("low_opacity"):
+        color.a = max(0, round(color.a * 0.7))
+    elif matches("very_low_opacity"):
+        color.a = max(0, round(color.a * 0.5))
+
+    # Temperature adjustments using RGB tinting (channels are 0-255)
+    if matches("very_high_temperature"):
+        color.r = min(255, color.r + 26)
+        color.g = max(0, color.g - 13)  # Add warmth by reducing green/blue tones
+    elif matches("high_temperature"):
+        color.r = min(255, color.r + 13)
+    elif matches("low_temperature"):
+        color.b = min(255, color.b + 13)  # Add coolness by increasing blue tones
+    elif matches("very_low_temperature"):
+        color.b = min(255, color.b + 26)
 
     return color
 
@@ -309,6 +314,10 @@ def color_from_description(description: str, lang: str = "en",
 
 
 def average_colors(colors: List[Color], weights: Optional[List[float]] = None) -> HLSColor:
+    if not colors:
+        raise ValueError("colors must be a non-empty list")
+    if weights is not None and len(weights) != len(colors):
+        raise ValueError("weights must have the same length as colors")
     colors = [c if isinstance(c, HLSColor) else c.as_hls for c in colors]
     weights = weights or [1 / len(colors) for c in colors]
 
@@ -400,22 +409,21 @@ def get_contrasting_black_or_white(hex_code: str) -> sRGBAColor:
     """
     color = sRGBAColor.from_hex_str(hex_code)
     yiq = ((color.r * 299) + (color.g * 587) + (color.b * 114)) / 1000
-    ccolor = sRGBAColor.from_hex_str("#000000", name="white") \
-        if yiq > 125 else sRGBAColor.from_hex_str("#ffffff", name="black")
+    ccolor = sRGBAColor.from_hex_str("#000000", name="black") \
+        if yiq > 125 else sRGBAColor.from_hex_str("#ffffff", name="white")
     return ccolor
 
 
 def is_hex_code_valid(hex_code: str) -> bool:
-    """Validate whether the input string is a valid hex color code."""
-    # TODO expand to validate 3 char codes.
+    """Validate whether the input string is a valid 3 or 6 digit hex color code."""
     hex_code = hex_code.lstrip("#")
-    try:
-        assert len(hex_code) == 6
-        int(hex_code, 16)
-    except (AssertionError, ValueError):
+    if len(hex_code) not in (3, 6):
         return False
-    else:
-        return True
+    try:
+        int(hex_code, 16)
+    except ValueError:
+        return False
+    return True
 
 
 def rgb_to_cmyk(r, g, b, cmyk_scale=100, rgb_scale=255) -> Tuple[float, float, float, float]:

--- a/ovos_color_parser/models.py
+++ b/ovos_color_parser/models.py
@@ -21,7 +21,7 @@ class sRGBAColor:
     description: Optional[str] = None
 
     def __hash__(self):
-        return int(f"{self.r}{self.g}{self.b}")
+        return hash((self.r, self.g, self.b, self.a))
 
     @property
     def as_spectral_color(self) -> 'SpectralColor':
@@ -33,7 +33,7 @@ class sRGBAColor:
         g = self.g / 255
         b = self.b / 255
         h, l, s = rgb_to_hls(r, g, b)
-        return HLSColor(int(h * 360), l, min(1, s),
+        return HLSColor(round(h * 360), l, min(1, s),
                         name=self.name,
                         description=self.description)
 
@@ -43,7 +43,7 @@ class sRGBAColor:
         g = self.g / 255
         b = self.b / 255
         h, s, v = rgb_to_hsv(r, g, b)
-        return HSVColor(int(h * 360), s, v,
+        return HSVColor(round(h * 360), s, v,
                         name=self.name,
                         description=self.description)
 
@@ -68,13 +68,11 @@ class sRGBAColor:
         return sRGBAColor(r, g, b, name=name, description=description)
 
     def __post_init__(self):
-        # Enforce hue values between 0 and 360
-        if not (0 <= self.r <= 255) or not (0 <= self.r <= 255):
+        # Enforce channel values between 0 and 255
+        if not (0 <= self.r <= 255 and 0 <= self.g <= 255 and 0 <= self.b <= 255):
             raise ValueError("RGB values must be in the range 0 to 255")
-        if not (0 <= self.g <= 255) or not (0 <= self.g <= 255):
-            raise ValueError("RGB values must be in the range 0 to 255")
-        if not (0 <= self.b <= 255) or not (0 <= self.b <= 255):
-            raise ValueError("RGB values must be in the range 0 to 255")
+        if not 0 <= self.a <= 255:
+            raise ValueError("Alpha value must be in the range 0 to 255")
 
 
 @dataclass
@@ -99,7 +97,7 @@ class HSVColor:
     @property
     def as_rgb(self) -> 'sRGBAColor':
         r, g, b = hsv_to_rgb(self.h / 360, self.s, self.v)
-        return sRGBAColor(int(r * 255), int(g * 255), int(b * 255),
+        return sRGBAColor(round(r * 255), round(g * 255), round(b * 255),
                           name=self.name,
                           description=self.description)
 
@@ -138,7 +136,7 @@ class HLSColor:
     @property
     def as_rgb(self) -> 'sRGBAColor':
         r, g, b = hls_to_rgb(self.h / 360, self.l, self.s)
-        return sRGBAColor(int(r * 255), int(g * 255), int(b * 255),
+        return sRGBAColor(round(r * 255), round(g * 255), round(b * 255),
                           name=self.name,
                           description=self.description)
 
@@ -563,10 +561,10 @@ EnglishColorTerms = LanguageColorVocabulary(terms=[
     ColorTerm("green", HueRange(90, 150), "#008000"),
     ColorTerm("cyan", HueRange(150, 180), "#00FFFF"),
     ColorTerm("blue", HueRange(180, 240), "#0000FF"),
-    ColorTerm("purple", HueRange(240, 270, "#800080")),
-    ColorTerm("magenta", HueRange(270, 300, "#FF00FF")),
-    ColorTerm("pink", HueRange(300, 330, "#FFC0CB")),
-    ColorTerm("red", HueRange(330, 360, "#FF0000"))
+    ColorTerm("purple", HueRange(240, 270), "#800080"),
+    ColorTerm("magenta", HueRange(270, 300), "#FF00FF"),
+    ColorTerm("pink", HueRange(300, 330), "#FFC0CB"),
+    ColorTerm("red", HueRange(330, 360), "#FF0000")
 ])
 
 # using xcolor and terms defined in https://www.nature.com/articles/s41599-022-01045-3


### PR DESCRIPTION
Fixes a set of correctness bugs in the color models and matching helpers:

- `get_contrasting_black_or_white` had the names swapped: it returned `#000000` named "white" and `#ffffff` named "black".
- Opacity descriptors ("opaque", "translucent", ...) crashed with `AttributeError`: the code read `color.a` on `HLSColor`, which has no alpha field. Opacity now adjusts the sRGBA alpha channel on the 0-255 scale.
- Temperature descriptors ("warm", "cool", ...) clamped 0-255 RGB channels with `min(1.0, ...)`, collapsing the adjusted channel to 1/255. Tinting now uses the 0-255 scale.
- `EnglishColorTerms` passed hex codes as the third positional argument of `HueRange` (its `name`), so purple/magenta/pink/red terms had no `hex_approximation` and a wrong name.
- `sRGBAColor.__hash__` concatenated channel digits into a string (collision-prone, e.g. (1,11,1) vs (11,1,1)); it now hashes the channel tuple.
- `sRGBAColor.__post_init__` validated `r` in every branch and never validated `a`; conditions fixed and alpha validated.
- Color space conversions truncated with `int()`, so `hex -> HLS -> hex` round-trips drifted; conversions now round, making round-trips stable.
- `is_hex_code_valid` accepts 3-digit codes, matching `from_hex_str`.
- `average_colors` raises a clear `ValueError` on an empty color list or mismatched weights instead of `ZeroDivisionError`.
- `ColorMatcher.match_color_automaton` / `match_object_automaton` returned single-use `zip` iterators annotated as a tuple; they now return lists of `(color, score)` tuples.
- `__init__.py` exports the remaining public helpers: `lookup_name`, `palette_from_description`, `is_hex_code_valid`, `rgb_to_cmyk`, `cmyk_to_rgb`, `ColorTerm`, `LanguageColorVocabulary`.
- Adds a standard Python `.gitignore` so compiled caches stay out of the tree.

🤖 Generated with [Claude Code](https://claude.com/claude-code)