### PR TITLE
feat: Kabyle (kab) color names

### DIFF
--- a/docs/languages.md
+++ b/docs/languages.md
@@ -19,6 +19,7 @@ subtag (`en`, `en-GB` → `en-US`). Unsupported languages make `color_from_descr
 | eu-ES | 8011 | yes | no | 5 |
 | fr-FR | 14712 | yes | yes | 16 |
 | it-IT | ~6900 | yes | no | 5 |
+| kab-DZ | 12 | no | no | 1 |
 | nl-NL | 101 | no | no | 1 |
 | pl-PL | 173 | no | no | 1 |
 | pt-BR | ~8300 | yes | yes | 15 |
@@ -31,6 +32,13 @@ subtag (`en`, `en-GB` → `en-US`). Unsupported languages make `color_from_descr
 
 Every public function accepts every language: locales lacking a resource degrade gracefully
 instead of raising.
+
+## Kabyle notes
+
+Kabyle colexifies blue and green: `azegzaw` covers both and is mapped to both hexes ("grue").
+`anili` (indigo), `azenǧǧari` (sky blue) and `amuri` (navy) name specific blues; `adal`,
+`azemmuri` (olive) and `aqesli` (light green) are attested greens. Only attested terms ship;
+modifier keywords are omitted for lack of sources.
 
 ## Wordlist sources
 

--- a/ovos_color_parser/res/kab-DZ/colors.json
+++ b/ovos_color_parser/res/kab-DZ/colors.json
@@ -1,0 +1,14 @@
+{
+  "#FF0000": "azeggaɣ",
+  "#FFFF00": "awraɣ",
+  "#000000": "aberkan",
+  "#FFFFFF": "amellal",
+  "#0000FF": "azegzaw",
+  "#008000": "azegzaw",
+  "#4B0082": "anili",
+  "#808080": "ademdam",
+  "#87CEEB": "azenǧǧari",
+  "#000080": "amuri",
+  "#808000": "azemmuri",
+  "#90EE90": "aqesli"
+}

--- a/test/test_languages.py
+++ b/test/test_languages.py
@@ -23,6 +23,7 @@ ANCHORS = {
     "eu": ("gorria", "urdina"),
     "fr": ("rouge", "bleu"),
     "it": ("rosso", "blu"),
+    "kab": ("azeggaɣ", "anili"),
     "nl": ("rood", "blauw"),
     "pl": ("czerwony", "niebieski"),
     "pt": ("vermelho", "azul"),


### PR DESCRIPTION
Adds `res/kab-DZ/colors.json`: attested Kabyle (Taqbaylit) basic color terms.

## Vocabulary decisions

- `azeggaɣ` red, `awraɣ` yellow, `aberkan` black, `amellal` white, `ademdam` gray
- **Grue**: Kabyle colexifies blue and green — `azegzaw` is mapped to both `#0000FF` and `#008000`
- Specific attested blues/greens: `anili` (indigo), `azenǧǧari` (sky blue), `amuri` (navy), `azemmuri` (olive green), `aqesli` (light green)

## Coverage boundary

Only terms traceable to the source below ship. Modifier keywords (`color_descriptors.json`), object colors, and terms like brown/pink/orange/violet were not found with verifiable Kabyle spellings and are omitted — locales without descriptors degrade gracefully. Notes added to `docs/languages.md`.

## Sources

- https://glosbe.com/fr/kab — rouge (`azeggaɣ`), jaune (`awraɣ`), noir (`aberkan`), blanc (`amellal`), bleu (`azegzaw`, `anili`, sky `azenǧǧari`, navy `amuri`), vert (`azegzaw`, olive `azemmuri`, light `aqesli`), gris (`ademdam`)

## Tests

`kab` anchor words added to `test/test_languages.py` (`azeggaɣ` reddish, `anili` bluish), exercised by the existing per-language parse/gibberish suite.

This PR was authored with Claude (Fable 5).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
