### PR TITLE
docs: cross-domain examples and full language coverage

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 # OVOS Color Parser
 
-Parse natural-language color descriptions into color objects, and name colors, in 13 languages.
+Turn natural-language color descriptions into color objects, and color objects back into
+names, in 23 languages. Pure Python, zero network, no ML model — just bundled wordlists and
+color math.
 
 ```python
 from ovos_color_parser import color_from_description
@@ -10,16 +12,32 @@ print(c.hex_str)   # "#371013"
 print(c.as_hls)    # HLSColor(h=352, l=0.145..., s=0.522..., ...)
 ```
 
-Designed for voice interfaces:
-
-- "change the lamp color to moss green"
-- "make it darker"
-- "a warmer white"
+It ships as part of the OpenVoiceOS voice stack, but it is a standalone library first: nothing
+here imports OVOS. It is equally useful for NER over free text, describing colors for
+text-to-speech, and mapping color descriptions to hex for UI theming or LED control.
 
 ## Installation
 
 ```bash
 pip install ovos-color-parser
+# or, with uv:
+uv pip install ovos-color-parser
+```
+
+## 30-second quickstart
+
+```python
+from ovos_color_parser import color_from_description, lookup_name, sRGBAColor
+
+# text -> color
+c = color_from_description("warm mustard yellow", lang="en")
+print(c.hex_str, (c.r, c.g, c.b))     # #F6BC26 (246, 188, 38)
+
+# color -> text (any supported language)
+print(lookup_name(sRGBAColor.from_hex_str("#1E90FF"), lang="pt"))  # "Dodger Azul"
+
+# nothing matches -> None
+print(color_from_description("qzxwv", lang="en"))  # None
 ```
 
 ## Features
@@ -35,11 +53,78 @@ pip install ovos-color-parser
   hue mean, Kelvin color temperature to RGB, CMYK conversion, contrasting black/white text color and
   hex validation.
 
+## Use it anywhere
+
+Every snippet below is plain Python — `pip install ovos-color-parser` and run it. Each has a
+matching runnable script in [examples/](examples/).
+
+### Extract colors from free text (NER)
+
+Pull color references out of a sentence and resolve each to a structured color — no ML model,
+no network. Great for tagging product copy, design briefs or support tickets.
+
+```python
+from ovos_color_parser import color_from_description
+
+text = "Paint the fence dark forest green and the door navy blue"
+for phrase in ("dark forest green", "navy blue"):
+    c = color_from_description(phrase, lang="en", fuzzy=False)
+    print(phrase, "->", c.hex_str)   # dark forest green -> #020C05 ; navy blue -> #0B32B4
+```
+
+Full sliding-window extractor with span offsets: [examples/ner_colors.py](examples/ner_colors.py).
+
+### Describe a color out loud (TTS-adjacent)
+
+Go the other way: a raw RGB/hex value from a color picker, sensor or smart bulb becomes a
+speakable name.
+
+```python
+from ovos_color_parser import sRGBAColor, lookup_name
+
+c = sRGBAColor.from_hex_str("#2E8B57")
+print(f"The color is {lookup_name(c, lang='en').lower()}.")   # "The color is sea green."
+```
+
+See [examples/describe_rgb.py](examples/describe_rgb.py).
+
+### Map descriptions to hex for UI, theming and LEDs
+
+```python
+from ovos_color_parser import color_from_description
+
+theme = {var: color_from_description(desc, lang="en").hex_str.lower()
+         for var, desc in {"--accent": "vivid teal", "--bg": "very dark blue"}.items()}
+print(theme)   # {'--accent': '#00d0cc', '--bg': '#070d24'}
+```
+
+CSS variables, NeoPixel/WLED tuples and Kelvin white-balance in
+[examples/ui_theming.py](examples/ui_theming.py).
+
+### In an OVOS skill vs. standalone
+
+The same call powers a voice intent and a plain script — only the surrounding code differs:
+
+```python
+# standalone color utility
+from ovos_color_parser import color_from_description
+hex_str = color_from_description("moss green", lang="en").hex_str
+
+# inside an OVOS skill handler
+def handle_set_color(self, message):
+    utterance = message.data["utterance"]
+    color = color_from_description(utterance, lang=self.lang)
+    if color:
+        self.set_lamp(color.hex_str)
+```
+
 ## Supported languages
 
-Basque, Catalan, Czech, Danish, Dutch, English, French, German, Italian, Polish, Portuguese, Russian
-and Spanish. Any BCP-47 tag resolves to the closest bundled locale (for example `en-GB` → `en-US`).
-The per-language feature matrix is in [docs/languages.md](docs/languages.md).
+23 locales: Aragonese, Arabic, Asturian, Basque, Bulgarian, Catalan, Croatian, Czech, Danish,
+Dutch, English, French, German, Italian, Kabyle, Occitan, Polish, Portuguese, Romanian, Russian,
+Slovak, Spanish and West Frisian. Any BCP-47 tag resolves to the closest bundled locale (for
+example `en-GB` → `en-US`). The per-language feature matrix — entry counts, modifier and object
+support — is in [docs/languages.md](docs/languages.md).
 
 ## Documentation
 
@@ -49,7 +134,17 @@ The per-language feature matrix is in [docs/languages.md](docs/languages.md).
 - [Color, language and color spaces](docs/color-theory.md) — how languages carve up
   color space, and the color models used
 - [API reference](docs/api.md)
-- [Language support](docs/languages.md)
+- [Language support](docs/languages.md) — the 23 locales and their per-language vocabulary
+- [Extending](docs/extending.md) — custom wordlists, adding a language, integration patterns
+
+### Runnable examples
+
+- [parse_colors.py](examples/parse_colors.py) — descriptions to colors, modifiers, `cast_to_palette`
+- [describe_rgb.py](examples/describe_rgb.py) — RGB/hex to a spoken color name (TTS)
+- [ner_colors.py](examples/ner_colors.py) — extract color spans from free text (NER)
+- [ui_theming.py](examples/ui_theming.py) — descriptions to CSS/LED/Kelvin values
+- [multilingual.py](examples/multilingual.py) — the same colors across all languages
+- [color_math.py](examples/color_math.py) — models, conversions, distance and averaging
 
 ## Usage notes
 

--- a/docs/extending.md
+++ b/docs/extending.md
@@ -1,0 +1,84 @@
+# Extending and integrating
+
+This page covers using the library outside a voice assistant, tuning the matcher, adding a
+language, and shipping your own wordlists.
+
+## Exact vs. fuzzy matching
+
+`color_from_description(..., fuzzy=True)` (the default) is forgiving: it tolerates typos and loose
+phrasing, which is what a spoken or typed request usually needs. The trade-off is that short filler
+words can incidentally match a color name.
+
+For entity extraction over arbitrary prose, pass `fuzzy=False`. Matching then requires a color name
+to appear as a substring, so words like "the", "door" or "keep" resolve to `None` and only genuine
+color phrases survive. [examples/ner_colors.py](../examples/ner_colors.py) builds a span extractor
+on top of this.
+
+```python
+from ovos_color_parser import color_from_description
+
+color_from_description("keep the door shut", fuzzy=True)   # may match something
+color_from_description("keep", fuzzy=False)                # None
+color_from_description("navy blue", fuzzy=False).hex_str   # '#0B32B4'
+```
+
+## Reusing the bundled modifier wordlists
+
+Locales with a `color_descriptors.json` ship saturation/brightness/temperature/opacity adjectives.
+You can read them to detect modifier words in your own text processing:
+
+```python
+from ovos_color_parser.matching import _get_color_adjectives
+
+adjectives = _get_color_adjectives("en")   # {"low_brightness": ["dark", ...], ...}
+modifiers = {w.lower() for group in adjectives.values() for w in group}
+"dark" in modifiers   # True
+```
+
+## Standalone vs. OVOS
+
+Nothing in the package imports OVOS, so the same call works in a script or a skill — only the input
+plumbing differs.
+
+```python
+# standalone
+from ovos_color_parser import color_from_description
+hex_str = color_from_description("moss green", lang="en").hex_str
+
+# inside a skill handler
+def handle_set_color(self, message):
+    color = color_from_description(message.data["utterance"], lang=self.lang)
+    if color:
+        self.set_lamp(color.hex_str)
+```
+
+Because `lang` is just a BCP-47 tag, wiring the library into any framework is a matter of passing
+that framework's active language through.
+
+## Custom wordlists at runtime
+
+Wordlists are plain `{"#RRGGBB": "name"}` JSON. To parse against your own palette, add a locale
+directory (see below) or reuse the models directly:
+
+```python
+from ovos_color_parser import sRGBAColor, closest_color
+
+brand = {"#0A66C2": "Brand Blue", "#F5A623": "Brand Amber", "#2E2E2E": "Brand Ink"}
+palette = [sRGBAColor.from_hex_str(h, name=n) for h, n in brand.items()]
+
+picked = closest_color(sRGBAColor.from_hex_str("#0B5FB0"), palette)
+print(picked.name)   # 'Brand Blue'
+```
+
+## Adding a language
+
+1. Create `ovos_color_parser/res/<lang>-<REGION>/colors.json` with `{"#RRGGBB": "name", ...}`.
+2. Optionally add more wordlist files (any `*.json` with the same shape) — they are all merged.
+3. Optionally add `color_descriptors.json` (copy the key structure from `en-US`) to enable
+   light/dark/vivid/warm/transparent modifiers, and `object_colors.json` for prototypical object
+   colors ("carrot", "banana").
+4. Add anchor words for the language to `test/test_languages.py`.
+
+A requested tag resolves to the closest bundled locale: exact case-insensitive tag first, then any
+locale sharing the primary language subtag. See [languages.md](languages.md) for the current
+locale list and per-language vocabulary notes.

--- a/docs/languages.md
+++ b/docs/languages.md
@@ -8,22 +8,34 @@ subtag (`en`, `en-GB` → `en-US`). Unsupported languages make `color_from_descr
 
 ## Feature matrix
 
-| Locale | Color name entries | Modifier keywords¹ | Object colors² | Wordlist files |
+| Locale | Language | Color name entries | Modifier keywords¹ | Object colors² |
 |---|---|---|---|---|
-| ca-ES | 3134 | no | no | 5 |
-| cs-CZ | 54 | no | no | 1 |
-| da-DK | 14712 | yes | yes | 16 |
-| de-DE | 1548 | yes | no | 4 |
-| en-US | 14712 | yes | yes | 16 |
-| es-ES | 7250 | yes | no | 4 |
-| eu-ES | 8011 | yes | no | 5 |
-| fr-FR | 14712 | yes | yes | 16 |
-| it-IT | ~6900 | yes | no | 5 |
-| kab-DZ | 12 | no | no | 1 |
-| nl-NL | 101 | no | no | 1 |
-| pl-PL | 173 | no | no | 1 |
-| pt-BR | ~8300 | yes | yes | 15 |
-| ru-RU | 216 | no | no | 1 |
+| an-ES | Aragonese | 14 | no | no |
+| ar-SA | Arabic | 23 | yes | no |
+| ast-ES | Asturian | 17 | no | no |
+| bg-BG | Bulgarian | 32 | no | no |
+| ca-ES | Catalan | 3134 | no | no |
+| cs-CZ | Czech | 54 | no | no |
+| da-DK | Danish | 14712 | yes | yes |
+| de-DE | German | 1548 | yes | no |
+| en-US | English | 14712 | yes | yes |
+| es-ES | Spanish | 7250 | yes | no |
+| eu-ES | Basque | 8011 | yes | no |
+| fr-FR | French | 14712 | yes | yes |
+| fy-NL | West Frisian | 15 | no | no |
+| hr-HR | Croatian | 30 | no | no |
+| it-IT | Italian | 6820 | yes | no |
+| kab-DZ | Kabyle | 12 | no | no |
+| nl-NL | Dutch | 101 | no | no |
+| oc-FR | Occitan | 23 | yes | no |
+| pl-PL | Polish | 173 | no | no |
+| pt-BR | Portuguese | 8238 | yes | yes |
+| ro-RO | Romanian | 101 | yes | no |
+| ru-RU | Russian | 216 | no | no |
+| sk-SK | Slovak | 35 | no | no |
+
+23 locales. `color_from_description` accepts any BCP-47 tag and resolves it to the closest
+bundled locale.
 
 ¹ `color_descriptors.json`: saturation/brightness/temperature/opacity adjectives ("dark", "vivid",
 "warm", "transparent"). Locales without it still match color names; modifiers are simply ignored.
@@ -32,6 +44,11 @@ subtag (`en`, `en-GB` → `en-US`). Unsupported languages make `color_from_descr
 
 Every public function accepts every language: locales lacking a resource degrade gracefully
 instead of raising.
+
+The largest wordlists (Danish, English, French) share the full ~14.7k-entry set covering web
+colors, the xkcd survey, crayola, RAL, Pantone and more. Smaller locales ship curated basic and
+traditional color terms; they resolve common names accurately but will snap unusual descriptions
+to a nearer basic color.
 
 ## Kabyle notes
 
@@ -48,8 +65,5 @@ traditional Japanese colors and Wikipedia's list of colors.
 
 ## Adding a language
 
-1. Create `ovos_color_parser/res/<lang>-<REGION>/colors.json` with `{"#RRGGBB": "name", ...}`.
-2. Optionally add more wordlist files (any `*.json` with the same shape).
-3. Optionally add `color_descriptors.json` (copy the key structure from `en-US`) and
-   `object_colors.json`.
-4. Add anchor words for the language to `test/test_languages.py`.
+See [extending.md](extending.md#adding-a-language) for the step-by-step guide to adding a locale,
+shipping custom wordlists, and enabling modifier keywords.

--- a/examples/describe_rgb.py
+++ b/examples/describe_rgb.py
@@ -1,0 +1,45 @@
+"""Reverse direction: turn a raw color into words you can speak or print.
+
+Given an RGB tuple or hex string (from a color picker, a sensor, a smart bulb,
+an image), produce a natural-language color name. Handy for TTS ("the light is
+now warm white"), accessibility labels, or alt-text.
+
+    pip install ovos-color-parser
+    python describe_rgb.py
+
+`lookup_name` snaps the color to the nearest entry in a language's wordlist and
+returns its name, so the same color speaks correctly in any supported language.
+"""
+from ovos_color_parser import sRGBAColor, lookup_name, get_contrasting_black_or_white
+
+
+def describe(rgb, lang: str = "en") -> str:
+    color = sRGBAColor(*rgb)
+    return lookup_name(color, lang=lang)
+
+
+if __name__ == "__main__":
+    samples = [
+        (255, 0, 0),
+        (30, 144, 255),
+        (255, 219, 88),
+        (46, 139, 87),
+        (128, 0, 128),
+        (245, 245, 220),
+    ]
+
+    print("RGB -> spoken color name (English)\n")
+    for rgb in samples:
+        hex_str = sRGBAColor(*rgb).hex_str
+        print(f"  {str(rgb):18} {hex_str}  ->  {describe(rgb)!r}")
+
+    print("\nSame colors, other languages\n")
+    for lang in ("en", "de", "fr", "pt", "ru"):
+        print(f"  {lang}: {describe((30, 144, 255), lang=lang)!r}")
+
+    print("\nHex from a color picker -> a sentence for TTS\n")
+    for hex_code in ("#2E8B57", "#FFB6C1", "#36454F"):
+        color = sRGBAColor.from_hex_str(hex_code)
+        name = lookup_name(color, lang="en")
+        ink = get_contrasting_black_or_white(hex_code).name  # readable label color
+        print(f"  {hex_code}: \"The color is {name.lower()}.\"  (label text: {ink})")

--- a/examples/multilingual.py
+++ b/examples/multilingual.py
@@ -15,6 +15,15 @@ WORDS = {
     "da": "rød",
     "ca": "vermell",
     "eu": "gorria",
+    "ar": "أحمر",
+    "ro": "roșu",
+    "sk": "červená",
+    "hr": "crvena",
+    "bg": "червено",
+    "oc": "roge",
+    "an": "royo",
+    "ast": "bermeyu",
+    "fy": "read",
 }
 
 for lang, word in WORDS.items():

--- a/examples/ner_colors.py
+++ b/examples/ner_colors.py
@@ -1,0 +1,85 @@
+"""NER / entity extraction: pull color mentions out of free text.
+
+No OVOS, no ML model, no network -- just the bundled color wordlists and a
+sliding window. Given a sentence, find the color phrases and resolve each to a
+structured color (name, hex, rgb). Useful for tagging product descriptions,
+design briefs, support tickets or any free text that mentions colors.
+
+    pip install ovos-color-parser
+    python ner_colors.py
+
+Strategy: color-name matching is substring based, so `fuzzy=False` keeps filler
+words ("the", "fence") from matching. We find maximal runs of consecutive words
+that each resolve on their own, then pull in immediately-adjacent modifier words
+("dark", "warm", "light") using the library's own bundled descriptor wordlists,
+and finally resolve the whole span together so the modifiers are applied.
+"""
+from dataclasses import dataclass
+from typing import List, Set
+
+from ovos_color_parser import color_from_description
+from ovos_color_parser.matching import _get_color_adjectives
+
+
+def _modifier_words(lang: str) -> Set[str]:
+    """Flatten the bundled saturation/brightness/temperature/opacity adjectives."""
+    words: Set[str] = set()
+    for group in _get_color_adjectives(lang).values():
+        words.update(w.lower() for w in group)
+    return words
+
+
+def _resolves(word: str, lang: str) -> bool:
+    return color_from_description(word, lang=lang, fuzzy=False) is not None
+
+
+@dataclass
+class ColorEntity:
+    text: str        # the exact span from the sentence
+    start: int       # word index where the span starts
+    end: int         # word index (exclusive) where it ends
+    hex: str         # resolved hex code
+    rgb: tuple       # resolved (r, g, b)
+
+
+def extract_colors(text: str, lang: str = "en") -> List[ColorEntity]:
+    words = [w.strip(".,;:!?\"'") for w in text.split()]
+    modifiers = _modifier_words(lang)
+    colorish = [_resolves(w, lang) for w in words]
+
+    entities: List[ColorEntity] = []
+    i = 0
+    while i < len(words):
+        if not colorish[i]:
+            i += 1
+            continue
+        # grow a run of consecutive resolving words
+        j = i
+        while j + 1 < len(words) and colorish[j + 1]:
+            j += 1
+        start, end = i, j + 1
+        # absorb a leading modifier ("dark forest green", "warm mustard")
+        while start > 0 and words[start - 1].lower() in modifiers:
+            start -= 1
+        phrase = " ".join(words[start:end])
+        color = color_from_description(phrase, lang=lang, fuzzy=False)
+        if color is not None:
+            entities.append(ColorEntity(phrase, start, end,
+                                        color.hex_str, (color.r, color.g, color.b)))
+        i = end
+    return entities
+
+
+if __name__ == "__main__":
+    text = ("Paint the fence dark forest green and the gate warm mustard "
+            "yellow, but keep the door navy blue.")
+    print(f"input: {text}\n")
+    for ent in extract_colors(text):
+        print(f"  [{ent.start}:{ent.end}] {ent.text!r:22} -> {ent.hex} rgb{ent.rgb}")
+
+    print()
+    # works in other languages too - just pass lang=
+    text_pt = "quero a parede verde escuro e o carro azul"
+    print(f"input (pt): {text_pt}\n")
+    for ent in extract_colors(text_pt, lang="pt"):
+        print(f"  [{ent.start}:{ent.end}] {ent.text!r:22} -> {ent.hex} rgb{ent.rgb}")

--- a/examples/ui_theming.py
+++ b/examples/ui_theming.py
@@ -1,0 +1,55 @@
+"""UI / design tooling: map color descriptions to hex, RGB and LED values.
+
+Turn typed or spoken color descriptions into concrete values you can feed to a
+CSS variable, a theme file, an RGB LED strip or an image library -- no OVOS
+required.
+
+    pip install ovos-color-parser
+    python ui_theming.py
+"""
+from ovos_color_parser import (color_from_description, sRGBAColor,
+                               get_contrasting_black_or_white, convert_K_to_RGB)
+
+
+def to_css_theme(spec: dict, lang: str = "en") -> dict:
+    """{"--accent": "vivid teal"} -> {"--accent": "#0aa4a4"}."""
+    theme = {}
+    for var, description in spec.items():
+        color = color_from_description(description, lang=lang)
+        if color is not None:
+            theme[var] = color.hex_str.lower()
+    return theme
+
+
+def to_led_rgb(description: str, lang: str = "en"):
+    """A description -> an (r, g, b) tuple ready for a NeoPixel / WLED call."""
+    color = color_from_description(description, lang=lang)
+    return None if color is None else (color.r, color.g, color.b)
+
+
+if __name__ == "__main__":
+    spec = {
+        "--bg": "very dark blue",
+        "--surface": "warm gray",
+        "--accent": "vivid teal",
+        "--danger": "bright red",
+    }
+    print("CSS theme from descriptions:\n")
+    theme = to_css_theme(spec)
+    for var, hex_str in theme.items():
+        text = get_contrasting_black_or_white(hex_str).name
+        print(f"  {var:12}: {hex_str}   (readable text: {text})")
+
+    print("\nLED strip values:\n")
+    for phrase in ["moss green", "hot pink", "amber", "electric blue"]:
+        print(f"  {phrase!r:16} -> setPixelColor{to_led_rgb(phrase)}")
+
+    print("\nWhite-balance a bulb by color temperature (Kelvin):\n")
+    for k in (2700, 4000, 6500):
+        c = convert_K_to_RGB(k)
+        print(f"  {k}K -> {c.hex_str} rgb({c.r}, {c.g}, {c.b})")
+
+    print("\nSame theming flow in Spanish:\n")
+    for var, hex_str in to_css_theme({"--acento": "verde vivo",
+                                      "--fondo": "azul oscuro"}, lang="es").items():
+        print(f"  {var:12}: {hex_str}")


### PR DESCRIPTION
Builds on the merged docs pass to cover standalone, non-OVOS use of the library and the languages added since.

## Examples (all runnable with `pip install ovos-color-parser`, no OVOS)
- `ner_colors.py` — extract color spans from free text and resolve each to a structured color; uses `fuzzy=False` so filler words don't match, absorbs adjacent modifiers, shows English and Portuguese.
- `describe_rgb.py` — RGB/hex to a spoken color name for TTS, in several languages, plus contrasting label color.
- `ui_theming.py` — descriptions to CSS variables, NeoPixel/WLED tuples and Kelvin white-balance.
- `multilingual.py` — expanded to all supported locales.

## Docs
- README: standalone-first framing, uv install, 30-second quickstart, a use-case section (NER / TTS / UI / OVOS-vs-standalone), and an example index.
- `docs/languages.md`: full 23-locale feature matrix with language names and entry counts.
- `docs/extending.md`: exact-vs-fuzzy matching, reusing modifier wordlists, standalone-vs-skill, custom wordlists, adding a language.

Docs and examples only; no library code changed. Each example was executed and its output verified.