### PR TITLE
feat: add Mirandese (mwl-PT) color locale

### DIFF
--- a/ovos_color_parser/res/mwl-PT/color_descriptors.json
+++ b/ovos_color_parser/res/mwl-PT/color_descriptors.json
@@ -1,0 +1,59 @@
+{
+  "very_high_saturation": [
+    "intenso",
+    "fuorte"
+  ],
+  "high_saturation": [
+    "intenso",
+    "fuorte"
+  ],
+  "low_saturation": [
+    "fraco",
+    "pálido"
+  ],
+  "very_low_saturation": [
+    "pálido",
+    "fraco"
+  ],
+  "very_high_brightness": [
+    "brilhante",
+    "luç",
+    "brilho"
+  ],
+  "high_brightness": [
+    "brilho",
+    "luç"
+  ],
+  "low_brightness": [
+    "scuro"
+  ],
+  "very_low_brightness": [
+    "scuro",
+    "negro"
+  ],
+  "very_high_temperature": [
+    "quente"
+  ],
+  "high_temperature": [
+    "quente"
+  ],
+  "low_temperature": [
+    "frio"
+  ],
+  "very_low_temperature": [
+    "frio"
+  ],
+  "very_high_opacity": [
+    "opaco",
+    "denso"
+  ],
+  "high_opacity": [
+    "denso"
+  ],
+  "low_opacity": [
+    "transparente"
+  ],
+  "very_low_opacity": [
+    "transparente"
+  ]
+}

--- a/ovos_color_parser/res/mwl-PT/colors.json
+++ b/ovos_color_parser/res/mwl-PT/colors.json
@@ -1,0 +1,17 @@
+{
+    "#FF0000": "burmeilho",
+    "#0000FF": "azul",
+    "#008000": "berde",
+    "#FFFF00": "amarielho",
+    "#FFA500": "laranja",
+    "#800080": "roixo",
+    "#EE82EE": "bioleta",
+    "#FFC0CB": "quelor de rosa",
+    "#A52A2A": "castanho",
+    "#000000": "negro",
+    "#FFFFFF": "branco",
+    "#808080": "cinzento",
+    "#A9A9A9": "cinza",
+    "#00FFFF": "ciano",
+    "#FF00FF": "magenta"
+}

--- a/test/test_lang_mwl.py
+++ b/test/test_lang_mwl.py
@@ -1,0 +1,47 @@
+"""Focused checks for the Mirandese (mwl-PT) color wordlist."""
+import unittest
+
+from ovos_color_parser import color_from_description, sRGBAColor
+
+
+def _h(c: sRGBAColor):
+    return c.as_hls.h
+
+
+class TestMirandese(unittest.TestCase):
+    lang = "mwl-PT"
+
+    def test_red_is_reddish(self):
+        c = color_from_description("burmeilho", self.lang)
+        self.assertIsNotNone(c)
+        h = _h(c)
+        self.assertTrue(h <= 40 or h >= 320, f"'burmeilho' -> {c.hex_str} not reddish")
+
+    def test_blue_is_bluish(self):
+        c = color_from_description("azul", self.lang)
+        self.assertIsNotNone(c)
+        self.assertTrue(180 <= _h(c) <= 280, f"'azul' -> {c.hex_str} not bluish")
+
+    def test_green_is_greenish(self):
+        c = color_from_description("berde", self.lang)
+        self.assertIsNotNone(c)
+        self.assertTrue(80 <= _h(c) <= 170, f"'berde' -> {c.hex_str} not greenish")
+
+    def test_yellow_is_yellowish(self):
+        c = color_from_description("amarielho", self.lang)
+        self.assertIsNotNone(c)
+        self.assertTrue(40 <= _h(c) <= 75, f"'amarielho' -> {c.hex_str} not yellowish")
+
+    def test_dark_modifier_darkens(self):
+        base = color_from_description("burmeilho", self.lang)
+        darker = color_from_description("burmeilho scuro", self.lang)
+        self.assertIsNotNone(darker)
+        self.assertLess(darker.as_hls.l, base.as_hls.l,
+                        "scuro modifier should reduce lightness")
+
+    def test_gibberish_returns_none(self):
+        self.assertIsNone(color_from_description("qzxwvqq", self.lang))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Adds a Mirandese (`mwl-PT`) color locale. Mirandese is the Astur-Leonese
language of Miranda do Douro. The loader auto-discovers
`ovos_color_parser/res/mwl-PT/`, so no code changes are required.

- `colors.json` — 15 hex → native Mirandese color names: burmeilho (red), azul
  (blue), berde (green), amarielho (yellow), laranja (orange), roixo (purple),
  bioleta (violet), quelor de rosa (pink), castanho (brown), negro (black),
  branco (white), cinzento / cinza (grey), ciano, magenta.
- `color_descriptors.json` — the 16 standard modifier keys populated only with
  attested Mirandese words (intenso, fuorte, fraco, pálido, brilho, brilhante,
  luç, scuro, negro, quente, frio, opaco, denso, transparente). Kept
  deliberately conservative.
- `test/test_lang_mwl.py` — asserts native basic colors resolve to the correct
  hue and that a darkening modifier ("scuro") lowers lightness.

Sources (verified, not engine-derived):
- RTP Ensina — *Vamos Aprender Mirandês*, Cores.
- Biquipédia (Mirandese Wikipedia), article *Quelor* — colour terms and the
  descriptive vocabulary (luç, brilho, scuro, saturaçon, intenso, pálido,
  quente, frio, fuorte, fraco).
- Wikivoyage / Wikitravel Mirandese phrasebook (roixo, bioleta, quelor de rosa).
- Wikcionário entry *burmeilho*.

Following "omit when uncertain": the set is a small, high-confidence core.
Terms whose Mirandese spelling could not be confirmed (e.g. gold/silver) were
left out rather than guessed, and the descriptor lists are short where the
lexicon was not attestable.
